### PR TITLE
msvc-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 #
 .build2/local/
 
+# IDEs
+.vs/
+.vscode/
+
 # Compiler/linker output.
 #
 *.d

--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 Build2 package for [google-benchmark](https://github.com/google/benchmark.git)
 
 `google-benchmark` does not support building shared libs on Windows when compiling with MSVC.
-This package will issue an error in this case.
-Always set `config.bin.lib=static` for this package.
+This package will issue an error in case `config.bin.lib=shared`. When `config.bin.lib=both`, only `liba{benchmark}` is built.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Google-Benchmark
 Build2 package for [google-benchmark](https://github.com/google/benchmark.git)
+
+`google-benchmark` does not support building shared libs on Windows when compiling with MSVC.
+This package will issue an error in this case.
+Always set `config.bin.lib=static` for this package.

--- a/build/export.build
+++ b/build/export.build
@@ -3,4 +3,7 @@ $out_root/
   include src/
 }
 
+if ($($out_root/src/ cxx.target.system) == 'win32-msvc')
+  assert ($import.target != libs{benchmark}) 'Google Benchmark only supports static library when using MSVC.'
+  
 export $out_root/src/$import.target

--- a/build/root.build
+++ b/build/root.build
@@ -13,4 +13,13 @@ test.target = $cxx.target
 # Upstream does not support this
 # Public headers are not marked appropriately with declspec(dllimport) and declspec(dllexport)
 # Causes severe problems with linking due to static variables and inline functions in headers
-assert! ($config.bin.lib != 'static' && $cxx.target.system == 'win32-msvc') 'Google Benchmark does not support building shared libs with MSVC. Explicitly set config.bin.lib=static when using MSVC'
+if ($cxx.target.system == 'win32-msvc')
+{
+  switch $config.bin.lib
+  {
+    case 'both'
+      bin.lib = static
+    case 'shared'
+      fail 'Google Benchmark does not support building shared libs with MSVC.'
+  }
+}

--- a/build/root.build
+++ b/build/root.build
@@ -8,3 +8,9 @@ cxx{*}: extension = cc
 # The test target for cross-testing (running tests under Wine, etc).
 #
 test.target = $cxx.target
+
+# Disable support for building shared libs on windows with msvc
+# Upstream does not support this
+# Public headers are not marked appropriately with declspec(dllimport) and declspec(dllexport)
+# Causes severe problems with linking due to static variables and inline functions in headers
+assert! ($config.bin.lib != 'static' && $cxx.target.system == 'win32-msvc') 'Google Benchmark does not support building shared libs with MSVC. Explicitly set config.bin.lib=static when using MSVC'

--- a/build/root.build
+++ b/build/root.build
@@ -15,7 +15,7 @@ test.target = $cxx.target
 # Causes severe problems with linking due to static variables and inline functions in headers
 if ($cxx.target.system == 'win32-msvc')
 {
-  switch $config.bin.lib
+  switch $bin.lib
   {
     case 'both'
       bin.lib = static

--- a/manifest
+++ b/manifest
@@ -6,6 +6,7 @@ license: Apache-2.0
 description-file: UPSTREAM_README.md
 url: https://github.com/google/benchmark.git
 package-email: swat.somebug@gmail.com
-depends: * build2 >= 0.13.0
-depends: * bpkg >= 0.13.0
+requires: c++11
+depends: * build2 >= 0.14.0
+depends: * bpkg >= 0.14.0
 #depends: libhello ^1.0.0

--- a/manifest
+++ b/manifest
@@ -7,6 +7,8 @@ description-file: UPSTREAM_README.md
 url: https://github.com/google/benchmark.git
 package-email: swat.somebug@gmail.com
 requires: c++11
+builds: default
+builds: -( +msvc &!static )
 depends: * build2 >= 0.14.0
 depends: * bpkg >= 0.14.0
 #depends: libhello ^1.0.0

--- a/src/buildfile
+++ b/src/buildfile
@@ -7,7 +7,12 @@ impl_libs = # Implementation dependencies.
 pub = [dir_path] ../include
 pub_hdrs = $pub/{$pub_hdrs}
 
-lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
+lib{benchmark}: libul{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
+lib{benchmark}: def{benchmark}: include = ($cxx.target.system == 'win32-msvc')
+def{benchmark}: libul{benchmark}
+if ($cxx.target.system == 'mingw32')
+  cxx.loptions += -Wl,--export-all-symbols
+
 liba{benchmark-main}: cxx{benchmark_main} lib{benchmark}
 
 # Build options.
@@ -22,6 +27,8 @@ if($cxx.target.class == 'linux')
   extra_libs += -lrt -lpthread
 elif ($cxx.target.class == 'macos')
   extra_libs += -lpthread
+elif ($cxx.target.class == 'windows')
+  extra_libs += shlwapi.lib
 
 cxx.libs = $extra_libs
 
@@ -35,6 +42,10 @@ lib{benchmark*}:
 
 liba{benchmark}: cxx.export.poptions += -DGOOGLE_BENCHMARK_STATIC
 libs{benchmark}: cxx.export.poptions += -DGOOGLE_BENCHMARK_SHARED
+
+# lib{benchmark-main} contains main which is not pulled out with msvc because no obj refers to it
+# Force include main in the final exe
+liba{benchmark-main}: bin.whole = true
 
 # For pre-releases use the complete version to make sure they cannot be used
 # in place of another pre-release or the final version. See the version module

--- a/src/buildfile
+++ b/src/buildfile
@@ -7,12 +7,7 @@ impl_libs = # Implementation dependencies.
 pub = [dir_path] ../include
 pub_hdrs = $pub/{$pub_hdrs}
 
-lib{benchmark}: libul{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
-lib{benchmark}: def{benchmark}: include = ($cxx.target.system == 'win32-msvc')
-def{benchmark}: libul{benchmark}
-if ($cxx.target.system == 'mingw32')
-  cxx.loptions += -Wl,--export-all-symbols
-
+lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
 liba{benchmark-main}: cxx{benchmark_main} lib{benchmark}
 
 # Build options.

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -1,6 +1,6 @@
 import libs = google-benchmark%lib{benchmark}
 
-if($config.bin.lib != shared)
+if($bin.lib != shared)
   import bm_main = google-benchmark%liba{benchmark-main}
 
 output_helper_path = [dir_path] ./google-benchmark-internal/output_test_helper/

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -37,7 +37,7 @@ for n : $basic_tests
   ./: exe{$n}: cxx{$n} $libs
 
 for n : $tests_w_output_helpers
-  ./: exe{$n}: cxx{$n} $output_helper_path/libul{output_test_helper}
+  ./: exe{$n}: cxx{$n} $output_helper_path/libue{output_test_helper}
 
 for n : {$basic_tests $tests_w_output_helpers}
 exe{$n}: test.options += --benchmark_min_time=0.01

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -33,7 +33,7 @@ tests_w_output_helpers = repetitions_test \
 
 tests_w_benchmark_main = link_main_test
 
-for n : $basic_test
+for n : $basic_tests
   ./: exe{$n}: cxx{$n} $libs
 
 for n : $tests_w_output_helpers

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -1,6 +1,6 @@
 import libs = google-benchmark%lib{benchmark}
 
-if($config.lib.bin != shared)
+if($config.bin.lib != shared)
   import bm_main = google-benchmark%liba{benchmark-main}
 
 output_helper_path = [dir_path] ./google-benchmark-internal/output_test_helper/
@@ -20,7 +20,6 @@ basic_tests = benchmark_test \
               args_product_test
 
 tests_w_output_helpers = repetitions_test \
-                         reporter_output_test \
                          templated_fixture_test \
                          user_counters_test \
                          perf_counters_test \
@@ -38,6 +37,12 @@ for n : $basic_tests
 
 for n : $tests_w_output_helpers
   ./: exe{$n}: cxx{$n} $output_helper_path/libue{output_test_helper}
+
+# reporter_output_test fails on windows due to hard coded linux path separator
+# Upstream also has the same issue. Include reporter_output_test once it is solved.
+exe{reporter_output_test}: $libs cxx{reporter_output_test}: include = ($cxx.target.class != 'windows')
+if ($cxx.target.class != 'windows')
+  ./: exe{reporter_output_test}
 
 for n : {$basic_tests $tests_w_output_helpers}
 exe{$n}: test.options += --benchmark_min_time=0.01

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -33,16 +33,14 @@ tests_w_output_helpers = repetitions_test \
 
 tests_w_benchmark_main = link_main_test
 
-for n : {$basic_tests $tests_w_output_helpers}
-{
+for n : $basic_test
   ./: exe{$n}: cxx{$n} $libs
-  exe{$n}: test.options += --benchmark_min_time=0.01
-}
 
 for n : $tests_w_output_helpers
-{
-  exe{$n}: $output_helper_path/liba{output_test_helper}
-}
+  ./: exe{$n}: cxx{$n} $output_helper_path/libul{output_test_helper}
+
+for n : {$basic_tests $tests_w_output_helpers}
+exe{$n}: test.options += --benchmark_min_time=0.01
 
 if($config.lib.bin != shared)
   ./: exe{$tests_w_benchmark_main}: cxx{$tests_w_benchmark_main} $bm_main

--- a/tests/basics/google-benchmark-internal/output_test_helper/buildfile
+++ b/tests/basics/google-benchmark-internal/output_test_helper/buildfile
@@ -1,5 +1,5 @@
 import libs = google-benchmark%lib{benchmark}
 
 internal_src = [dir_path] ../src
-./: libul{output_test_helper}: cxx{output_test_helper} hxx{output_test} $internal_src/hxx{**} $libs
+./: libue{output_test_helper}: cxx{output_test_helper} hxx{output_test} $internal_src/hxx{**} $libs
 cxx.poptions += "-I$src_base"

--- a/tests/basics/google-benchmark-internal/output_test_helper/buildfile
+++ b/tests/basics/google-benchmark-internal/output_test_helper/buildfile
@@ -1,5 +1,5 @@
 import libs = google-benchmark%lib{benchmark}
 
 internal_src = [dir_path] ../src
-./: liba{output_test_helper}: cxx{output_test_helper} hxx{output_test} $internal_src/hxx{**} $libs
-cxx.coptions += "-I$src_base"
+./: libul{output_test_helper}: cxx{output_test_helper} hxx{output_test} $internal_src/hxx{**} $libs
+cxx.poptions += "-I$src_base"


### PR DESCRIPTION
Working implementation of on msvc.
To merge in:

- [X] ~~Builds with MSVC with default configuration (`config.bin.lib=both`)~~
* Even though the library itself can be built as a shared lib, several features of the library cannot be used since `upstream` doesn't support it. 
- [X] ~~Builds when `config.bin.lib=shared`~~
* Seems to be a problem with [upstream](https://github.com/google/benchmark) regarding support of shared libs on windows reported under: google/benchmark#640.
* Confirm: Same issue as above. Shared lib is not supported by `upstream` with msvc.
* Shared libs with `msvc` is unsupported. Confirmed to be the same root issue as in the link above.
- [X] Builds when `config.bin.lib=static`
- [X] All tests pass
* Currently `tests/basics/exe{reporter_output_test}` fails with non-zero error code. This is general problem even with `upstream` on windows due to incorrect path separator. However, `ctest` for some reason doesn't detect this and flags as a pass.
* `tests/basics/exe{reporter_output_test}` is disabled on `windows`