### PR TITLE
Fix nondeterministic target setup order

### DIFF
--- a/buildfile
+++ b/buildfile
@@ -1,4 +1,4 @@
-./: {src/ -build/ -upstream/} doc{UPSTREAM_README.md} legal{LICENSE} manifest
+./: {*/ -build/ -upstream/} doc{UPSTREAM_README.md} legal{LICENSE} manifest
 
 # Don't install tests.
 #

--- a/buildfile
+++ b/buildfile
@@ -1,4 +1,4 @@
-./: {*/ -build/ -upstream/} doc{UPSTREAM_README.md} legal{LICENSE} manifest
+./: {src/ -build/ -upstream/} doc{UPSTREAM_README.md} legal{LICENSE} manifest
 
 # Don't install tests.
 #

--- a/src/buildfile
+++ b/src/buildfile
@@ -5,9 +5,9 @@ impl_libs = # Implementation dependencies.
 ./: lib{benchmark} liba{benchmark-main}
 
 pub = [dir_path] ../include
-include($pub)
+pub_hdrs = $pub/{$pub_hdrs}
 
-lib{benchmark}: cxx{* -benchmark_main} hxx{* $pub/benchmark/benchmark} 
+lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
 liba{benchmark-main}: cxx{benchmark_main} lib{benchmark}
 
 cxx.poptions =+ "-I$out_root/include" "-I$src_root/include" 

--- a/src/buildfile
+++ b/src/buildfile
@@ -5,6 +5,7 @@ impl_libs = # Implementation dependencies.
 ./: lib{benchmark} liba{benchmark-main}
 
 pub = [dir_path] ../include
+include $pub
 pub_hdrs = $pub/{$pub_hdrs}
 
 lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs

--- a/src/buildfile
+++ b/src/buildfile
@@ -5,9 +5,9 @@ impl_libs = # Implementation dependencies.
 ./: lib{benchmark} liba{benchmark-main}
 
 pub = [dir_path] ../include
-pub_hdrs = $pub/{$pub_hdrs}
+include($pub)
 
-lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
+lib{benchmark}: cxx{* -benchmark_main} hxx{* $pub/benchmark/benchmark} 
 liba{benchmark-main}: cxx{benchmark_main} lib{benchmark}
 
 cxx.poptions =+ "-I$out_root/include" "-I$src_root/include" 


### PR DESCRIPTION
It was noticed that occasionally (or always for GCC?), the order of target setup (that is, targets `include/` & `src/` respectively) were not setup correctly. For GCC a patched version is required, which is generated by the `include/` target. This must happen before setting up/building the `/src` target but this was not the case.

This PR just makes it explicit in what order things are setup. Verified multiple times switching back and forth between master & this branch (and `bdep deinit @gcc && bdep init @gcc` inbetween).

Tested with GCC 10, GCC 11 & Clang 13.