### PR TITLE
Reverting build strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Google-Benchmark
 Build2 package for [google-benchmark](https://github.com/google/benchmark.git)
 
+This package exports `lib{benchmark}` and `liba{benchmark_main}` targets. Linking against `liba{benchmark_main}` automatically links with `lib{benchmark}`. Consumers would mostly link against `lib{benchmark}` and calling `BENCHMARK_MAIN()` in one translation unit.
+If consumers don't define want to or cannot call `BENCHMARK_MAIN()` then linking against `liba{benchmark_main}` allows `main` to be defined.
+
 The package uses and installs a patched version of `benchmark/benchmark.h` in order to build with `gcc`. The issue is summarized below.
  1. `gcc` errors out if macros are expanded when `-fdirectives_only` is used
  2. `build2` passes this flag for the header extraction which can be turned off while building `google-benchmark` itself.

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: google-benchmark
-version: 1.7.0
+version: 1.7.0+1
 summary: Build2 package for google benchmark
 license: Apache-2.0
 description-file: UPSTREAM_README.md

--- a/src/buildfile
+++ b/src/buildfile
@@ -13,11 +13,8 @@ liba{benchmark_main}: cxx{benchmark_main} lib{benchmark}
 
 cxx.poptions =+ "-I$out_root/include" "-I$src_root/include" 
 
-# windows_additional_defines = 
-# if($cxx.target.system == 'win32-msvc')
-#   windows_additional_defines = '-D_CRT_SECURE_NO_WARNINGS'
-
-# cxx.poptions += $windows_additional_defines
+if($cxx.target.system == 'win32-msvc')
+  cxx.poptions += '-D_CRT_SECURE_NO_WARNINGS' # Internal, not exported
 
 obja{*}: cxx.poptions += -DBENCHMARK_STATIC_DEFINE
 objs{*}: cxx.poptions += -Dbenchmark_EXPORTS
@@ -38,7 +35,6 @@ cxx.libs = $intf_libs $extra_libs
 #
 lib{benchmark}:
 {
-  # cxx.export.poptions += "-I$out_root/include" "-I$src_root/include" $windows_additional_defines
   cxx.export.poptions += "-I$out_root/include" "-I$src_root/include"
   cxx.export.libs = $intf_libs $extra_libs
 }
@@ -64,10 +60,8 @@ hxx{*}: install = false
 if $version.pre_release
 {
   lib{benchmark}: bin.lib.version = @"-$version.project_id"
-  liba{benchmark_main}: bin.lib.version = @"-$version.project_id"
 }
 else
 {
   lib{benchmark}: bin.lib.version = @"-$version.major.$version.minor"
-  liba{benchmark_main}: bin.lib.version = @"-$version.major.$version.minor"
 }

--- a/src/buildfile
+++ b/src/buildfile
@@ -2,23 +2,22 @@ intf_libs = # Interface dependencies.
 impl_libs = # Implementation dependencies.
 #import impl_libs += libhello%lib{hello}
 
-./: lib{benchmark} lib{benchmark_main}
+./: lib{benchmark} liba{benchmark_main}
 
 pub = [dir_path] ../include
 include $pub
 pub_hdrs = $pub/{$pub_hdrs}
 
-libul{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
-lib{benchmark}: libul{benchmark}
-lib{benchmark_main}: cxx{benchmark_main} libul{benchmark}
+lib{benchmark}: cxx{* -benchmark_main} hxx{*} $pub/$pub_hdrs
+liba{benchmark_main}: cxx{benchmark_main} lib{benchmark}
 
 cxx.poptions =+ "-I$out_root/include" "-I$src_root/include" 
 
-windows_additional_defines = 
-if($cxx.target.system == 'win32-msvc')
-  windows_additional_defines = '-D_CRT_SECURE_NO_WARNINGS'
+# windows_additional_defines = 
+# if($cxx.target.system == 'win32-msvc')
+#   windows_additional_defines = '-D_CRT_SECURE_NO_WARNINGS'
 
-cxx.poptions += $windows_additional_defines
+# cxx.poptions += $windows_additional_defines
 
 obja{*}: cxx.poptions += -DBENCHMARK_STATIC_DEFINE
 objs{*}: cxx.poptions += -Dbenchmark_EXPORTS
@@ -37,17 +36,21 @@ cxx.libs = $intf_libs $extra_libs
 
 # Export options.
 #
-lib{benchmark*}:
+lib{benchmark}:
 {
-  cxx.export.poptions += "-I$out_root/include" "-I$src_root/include" $windows_additional_defines
+  # cxx.export.poptions += "-I$out_root/include" "-I$src_root/include" $windows_additional_defines
+  cxx.export.poptions += "-I$out_root/include" "-I$src_root/include"
   cxx.export.libs = $intf_libs $extra_libs
 }
 liba{benchmark}: cxx.export.poptions =+ -DBENCHMARK_STATIC_DEFINE
-liba{benchmark_main}: cxx.export.poptions =+ -DBENCHMARK_STATIC_DEFINE
 
-# lib{benchmark_main} contains main which is not pulled out with msvc because no obj refers to it
+# liba{benchmark_main} contains main which is not pulled out with msvc because no obj refers to it
 # Force include main in the final exe
-liba{benchmark_main}: bin.whole = true
+liba{benchmark_main}:
+{
+  cxx.export.libs += lib{benchmark}
+  bin.whole = true
+}
 
 
 # Disable install of non-public headers
@@ -61,10 +64,10 @@ hxx{*}: install = false
 if $version.pre_release
 {
   lib{benchmark}: bin.lib.version = @"-$version.project_id"
-  lib{benchmark_main}: bin.lib.version = @"-$version.project_id"
+  liba{benchmark_main}: bin.lib.version = @"-$version.project_id"
 }
 else
 {
   lib{benchmark}: bin.lib.version = @"-$version.major.$version.minor"
-  lib{benchmark_main}: bin.lib.version = @"-$version.major.$version.minor"
+  liba{benchmark_main}: bin.lib.version = @"-$version.major.$version.minor"
 }

--- a/tests/basics/buildfile
+++ b/tests/basics/buildfile
@@ -1,5 +1,5 @@
 import libs = google-benchmark%lib{benchmark}
-import bm_main = google-benchmark%lib{benchmark_main}
+import bm_main = google-benchmark%liba{benchmark_main}
 
 output_helper_path = [dir_path] ./google-benchmark-internal/output_test_helper/
 include $output_helper_path


### PR DESCRIPTION
  - Build only liba{benchmark_main}
  - liba{benchmark_main} exports lib{benchmark}
  - Removing disable of CRT_SECURE_WARNINGS
  - exe{link_main_test} links with liba{benchmark_main}
Updating README

Fixes #11 